### PR TITLE
Update minimum task runtime

### DIFF
--- a/shadow/algorithms/heuristic.py
+++ b/shadow/algorithms/heuristic.py
@@ -369,7 +369,7 @@ def insertion_policy(workflow, position=0, progress=False):
                 makespan = aft
             solution.add_allocation(task=task, machine=m, ast=ast, aft=aft)
         if progress:
-            update = len(solution.allocations) - update
+            update = 1
             pbar.update(update)
     if progress:
         pbar.close()

--- a/shadow/algorithms/heuristic.py
+++ b/shadow/algorithms/heuristic.py
@@ -51,12 +51,12 @@ def heft(workflow, position=0):
 
     if workflow.env is None:
         raise RuntimeError("Workflow environment is not initialised")
-    LOGGER.debug('Ranking tasks')
-    task_ranks = calculate_upward_ranks(workflow, position, True)
+    LOGGER.info('Ranking tasks')
+    task_ranks = calculate_upward_ranks(workflow, position, progress=False)
     for task in workflow.tasks:
         task.rank = task_ranks[task]
-    LOGGER.debug('Allocating tasks using insertion policy')
-    solution = insertion_policy(workflow, position, True)
+    LOGGER.info('Allocating tasks using insertion policy')
+    solution = insertion_policy(workflow, position, progress=False)
     return solution
 
 
@@ -197,9 +197,6 @@ def calculate_upward_ranks(workflow, position=0, progress=True):
             unranked.remove(node)
 
     _ranked_node_count = 1
-
-
-    _ranked_node_count = 1
     _total_nodes = len(workflow.graph.nodes())
     pbar = None
     if progress:
@@ -318,7 +315,7 @@ def calc_est(workflow, task, machine, solution):
     return est
 
 
-def insertion_policy(workflow, position=0, progress=True):
+def insertion_policy(workflow, position=0, progress=False):
     """
     Allocate tasks to machines following the insertion based policy outline
     in Tocuoglu et al.(2002)
@@ -373,7 +370,7 @@ def insertion_policy(workflow, position=0, progress=True):
             solution.add_allocation(task=task, machine=m, ast=ast, aft=aft)
         if progress:
             update = len(solution.allocations) - update
-            pbar.update()
+            pbar.update(update)
     if progress:
         pbar.close()
     solution.makespan = makespan

--- a/shadow/algorithms/heuristic.py
+++ b/shadow/algorithms/heuristic.py
@@ -52,11 +52,11 @@ def heft(workflow, position=0):
     if workflow.env is None:
         raise RuntimeError("Workflow environment is not initialised")
     LOGGER.debug('Ranking tasks')
-    task_ranks = calculate_upward_ranks(workflow, position)
+    task_ranks = calculate_upward_ranks(workflow, position, True)
     for task in workflow.tasks:
         task.rank = task_ranks[task]
     LOGGER.debug('Allocating tasks using insertion policy')
-    solution = insertion_policy(workflow, position)
+    solution = insertion_policy(workflow, position, True)
     return solution
 
 
@@ -195,6 +195,9 @@ def calculate_upward_ranks(workflow, position=0, progress=True):
             task_ranks[node] = max(
                 node.calc_ave_runtime(workflow.env) + longest_rank, 0)
             unranked.remove(node)
+
+    _ranked_node_count = 1
+
 
     _ranked_node_count = 1
     _total_nodes = len(workflow.graph.nodes())
@@ -370,7 +373,7 @@ def insertion_policy(workflow, position=0, progress=True):
             solution.add_allocation(task=task, machine=m, ast=ast, aft=aft)
         if progress:
             update = len(solution.allocations) - update
-            pbar.update(len(solution.allocations))
+            pbar.update()
     if progress:
         pbar.close()
     solution.makespan = makespan

--- a/shadow/models/workflow.py
+++ b/shadow/models/workflow.py
@@ -87,7 +87,7 @@ class Task(object):
             else:
                 data = 0
             compute = int(np.round(self.flops_demand / machine.flops))
-            if(compute < 1):
+            if compute < 1:
                 compute = 1
             return max(compute,
                        data)  # return  # self.calculated_runtime[machine]
@@ -145,10 +145,10 @@ class Task(object):
                        key=operator.itemgetter(1))
         else:
             cm = max(env.machines, key=operator.attrgetter('flops'))
-            cw = int(np.round(self.flops_demand / cm.flops))
+            cw = max(int(np.round(self.flops_demand / cm.flops)), 1)
             if cm.iorate:
                 iom = max(env.machines, key=operator.attrgetter('iorate'))
-                iow = int(np.round(self.io_demand / iom.iorate))
+                iow = max(int(np.round(self.io_demand / iom.iorate)),1)
                 if iow > cw:
                     return iom, iow
                 else:

--- a/shadow/models/workflow.py
+++ b/shadow/models/workflow.py
@@ -87,6 +87,8 @@ class Task(object):
             else:
                 data = 0
             compute = int(np.round(self.flops_demand / machine.flops))
+            if(compute < 1):
+                compute = 1
             return max(compute,
                        data)  # return  # self.calculated_runtime[machine]
 


### PR DESCRIPTION
This ensure the minimum time possible for a node is 1 timestep, removing the possibility of 'instantaneous' tasks being allocated onto a machine; this has the potential for allocating 100s or 1000s or tasks onto one machine because, according to the insertion policy mechansim, the finish time is the same. 